### PR TITLE
定时自动部署secrets参数名错误

### DIFF
--- a/tencentScf/README.md
+++ b/tencentScf/README.md
@@ -88,7 +88,7 @@ Actions 使用 `Serverless Framework` 来部署，通过 `serverless.yml` 来配
 
 | 配置名称 | Name | Value |
 | :----: | :----: | :----: |
-| 定时自动部署 | `IsAutoDeployTencentScf` | true |
+| 定时自动部署 | `IS_AUTO_DEPLOY_TENCENT_SCF` | true |
 
 自动部署只是定时会将自己仓库的代码部署到云函数，想要自动更新，还需要开启仓库的自动同步，详见常见问题文档中的 《我 Fork 之后如何同步原作者的更新内容？》章节
 


### PR DESCRIPTION
按照文档进行部署，一直运行了没反应，action的第二步走不通，看workflow文件才发现获取的环境变量参数名是IS_AUTO_DEPLOY_TENCENT_SCF

<!-- 因为源仓库收到大量辣鸡PR请求，所以请在发起PR前先仔细阅读以下内容 -->
<!-- 该操作会向作者源仓库发起PR，是用来向源仓库贡献自己代码的，并不是用来更改自己代码或拉取更新的。如向源仓库发起无用的辣鸡PR，会被关闭，严重地会进行拉黑处理 -->
<!-- 如果您明白您正在做什么，请将下一行中符号【】内的文字由“no”修改为“yes”（不含引号） -->
<!-- 您将向源仓库发起PR贡献代码，请问您是否明白：【yes】 -->

【内容】：
定时自动部署secrets参数名错误